### PR TITLE
Revert "candles/trades: make trade symbol prefix configurable"

### DIFF
--- a/config/moonbeam.history.conf.json.example
+++ b/config/moonbeam.history.conf.json.example
@@ -2,6 +2,5 @@
   "redisUrl": "127.0.0.1",
   "redisPort": 6379,
   "redisListName": "test_foo",
-  "interval": 50,
-  "tradeSymbolPrefix": "P"
+  "interval": 50
 }

--- a/workers/moonbeam.history.js
+++ b/workers/moonbeam.history.js
@@ -16,7 +16,7 @@ class MoonbeamHistory {
     const trade = {
       id: id,
       pair: pair,
-      symbol: this.conf.tradeSymbolPrefix + pair,
+      symbol: 't' + pair,
       t: t / 1000,
       price: price,
       amount: amount,


### PR DESCRIPTION
This reverts commit e8ee53f793d436fedfa3ea670fe83590127b6579.