### PR TITLE
add support for unique uint ids from websocket plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,16 @@ node worker.js
 ```
 
 
-## developmeent
+## Developmeent
 
 ```
 mongod --config /usr/local/etc/mongod.conf
+```
+
+## Indexes
+
+```js
+db.userdata.createIndex({ "ts": 1 })
+db.userdata.createIndex({ "username": 1 })
+db.userdata.createIndex({ "uintId": 1 }, { "unique": true })
 ```

--- a/workers/moonbeam.history.js
+++ b/workers/moonbeam.history.js
@@ -2,6 +2,7 @@
 
 const Redis = require('ioredis')
 const async = require('async')
+const Long = require('mongodb').Long
 
 class MoonbeamHistory {
   constructor (conf, db) {
@@ -10,11 +11,12 @@ class MoonbeamHistory {
   }
 
   handleTrade (msg) {
-    const [pair, , tr] = msg
+    const [pair, , tr, , uintId] = msg
     const [id, t, amount, price] = tr
 
     const trade = {
       id: id,
+      uintId: uintId,
       pair: pair,
       symbol: 't' + pair,
       t: t / 1000,
@@ -40,7 +42,7 @@ class MoonbeamHistory {
       }
       const parsed = JSON.parse(data)
 
-      let [, type, entry] = parsed
+      let [, type, entry, , uintId] = parsed
 
       if (type === 'te') {
         this.handleTrade(parsed)
@@ -56,6 +58,7 @@ class MoonbeamHistory {
       }
 
       const doc = {
+        uintId: Long.fromString(uintId),
         username: username,
         ts: ts,
         entry: parsed


### PR DESCRIPTION
support uint ids as unique index to allow chain replays after
the plugin has crashed.

also adds support for multiple websocket plugins, which will
generate unique uids.

for migration of old data a pluign instance would create a replay
which is put into a new redis queue, qhich fill a new database.

once all the data is replayed, the production db can be rotated.

index creation example:

```js
db.userdata.createIndex({ "uintId": 1 }, { "unique": true })
```

depends on: https://github.com/bitfinexcom/bfx-facs-db-mongo/pull/3