### PR TITLE
fees: add fee support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,7 @@ mongod --config /usr/local/etc/mongod.conf
 db.userdata.createIndex({ "ts": 1 })
 db.userdata.createIndex({ "username": 1 })
 db.userdata.createIndex({ "uintId": 1 }, { "unique": true })
+
+db.fees.createIndex({ "ts": 1, "username": 1 })
+db.fees.createIndex({ "uintId": 1 }, { "unique": true })
 ```

--- a/config/mongo.userdata.conf.json.example
+++ b/config/mongo.userdata.conf.json.example
@@ -1,6 +1,6 @@
 {
   "dbName": "foo_history",
   "mongoUrl": "mongodb://localhost",
-  "collection": "userdata",
-  "indexes": [{ "ts": 1 }, { "username": 1 }]
+  "collection_trades": "userdata",
+  "collection_fees": "fees"
 }


### PR DESCRIPTION
store fees in a seperate mongo collection for each trade update.

removes support for "on the fly indexing" on worker start. indexes
have to be created via mongo cli now.